### PR TITLE
adding "micron" to allowed scale types

### DIFF
--- a/PyTIE/TIE_helper.py
+++ b/PyTIE/TIE_helper.py
@@ -251,7 +251,7 @@ def read_image(f):
 
             if im["pixelUnit"][0] == "nm":
                 scale = im["pixelSize"][0]
-            elif im["pixelUnit"][0] in ["um", "µm"]:
+            elif im["pixelUnit"][0] in ["um", "µm", "micron"]:
                 scale = im["pixelSize"][0] * 1000
             elif im["pixelUnit"][0] == "mm":
                 scale = im["pixelSize"][0] * 1e6

--- a/PyTIE/TIE_reconstruct.py
+++ b/PyTIE/TIE_reconstruct.py
@@ -147,7 +147,8 @@ def TIE(
     bottom, top = ptie.crop["bottom"], ptie.crop["top"]
     dim_y = bottom - top
     dim_x = right - left
-    tifs = select_tifs(i, ptie, long_deriv)
+    tifs = np.array(select_tifs(i, ptie, long_deriv))
+    tifs -= np.min(tifs) # no negative values, can arise from alignment or filtering
 
     if sym:
         vprint("Reconstructing with symmetrized image.")


### PR DESCRIPTION
adding "micron" to allowed scale types, TIE() now shifts image so no negative values after select_tifs()